### PR TITLE
add flex center

### DIFF
--- a/Sources/KarrotFlex/FlexLayout+Sugar.swift
+++ b/Sources/KarrotFlex/FlexLayout+Sugar.swift
@@ -84,3 +84,83 @@ public func FlexInset(_ flex: Flex, all: CGFloat) -> Flex {
   return flex
     .padding(all)
 }
+
+// MARK: - Center
+
+public enum FlexCenterOption {
+  case X
+  case Y
+  case XY
+}
+
+@discardableResult
+public func FlexCenter(_ flex: Flex, option: FlexCenterOption, _ child: @escaping (Flex) -> Flex) -> Flex {
+  switch option {
+  case .X:
+    return flex
+      .addItem()
+      .width(100%)
+      .height(100%)
+      .direction(.row)
+      .justifyContent(.center)
+      .define {
+        // NOTE: discard result
+        _ = child($0)
+      }
+  case .Y:
+    return flex
+      .addItem()
+      .width(100%)
+      .height(100%)
+      .direction(.column)
+      .justifyContent(.center)
+      .define {
+        // NOTE: discard result
+        _ = child($0)
+      }
+  case .XY:
+    return flex
+      .addItem()
+      .width(100%)
+      .height(100%)
+      .justifyContent(.center)
+      .define {
+        child($0).alignSelf(.center)
+      }
+  }
+}
+
+@discardableResult
+public func FlexCenter(_ flex: Flex, option: FlexCenterOption, view: UIView) -> Flex {
+  switch option {
+  case .X:
+    return flex
+      .addItem()
+      .width(100%)
+      .height(100%)
+      .direction(.row)
+      .justifyContent(.center)
+      .define {
+        $0.addItem(view)
+      }
+  case .Y:
+    return flex
+      .addItem()
+      .width(100%)
+      .height(100%)
+      .direction(.column)
+      .justifyContent(.center)
+      .define {
+        $0.addItem(view)
+      }
+  case .XY:
+    return flex
+      .addItem()
+      .width(100%)
+      .height(100%)
+      .justifyContent(.center)
+      .define {
+        $0.addItem(view).alignSelf(.center)
+      }
+  }
+}


### PR DESCRIPTION
```swift
FlexCenter(overlay, option: .XY) { center in
  FlexItem(center, view: self.indexLabel)
}
```
or
```swift
FlexCenter(
  overlay,
  option: .XY,
  view: self.indexLabel
)
```

### option Y
<img width="108" alt="스크린샷 2021-11-03 오후 9 13 37" src="https://user-images.githubusercontent.com/19504988/140059419-83c42fe9-d8a6-42d5-85a5-7d0221ad4a4f.png">

### option X
<img width="124" alt="스크린샷 2021-11-03 오후 9 13 21" src="https://user-images.githubusercontent.com/19504988/140059425-3b4b8c25-b26c-46d7-9380-1f3965670856.png">

### option XY
<img width="145" alt="스크린샷 2021-11-03 오후 9 25 22" src="https://user-images.githubusercontent.com/19504988/140059529-67410135-ef7e-4d47-a8f3-7a7e022bd313.png">
