### PR TITLE
Fix pod trunk warning (resolve #17)

### DIFF
--- a/KarrotFlex.podspec
+++ b/KarrotFlex.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Geektree0101' => 'david@daangn.com' }
   s.source           = { :git => 'https://github.com/daangn/KarrotFlex.git', :tag => s.version.to_s }
+  s.swift_version = '5.5'
   s.ios.deployment_target = '9.0'
   s.source_files = 'Sources/KarrotFlex/**/*'
   s.dependency 'FlexLayout', '~> 1.3'


### PR DESCRIPTION
## issue
- pod trunk warning (resolve #17)

## solution
- add swift_version to KarrotFlex.podspec

## info
- [swift_versions](https://guides.cocoapods.org/syntax/podspec.html#swift_versions)
