### PR TITLE
Add detailed installation for SPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ let package = Package(
 )
 ```
 
+In your Xcode target:
+
+Add `FLEXLAYOUT_SWIFT_PACKAGE=1` to the build setting.  
+(TARGET -> Build Settings -> Apple Clang - Preprocessing -> Preprocessor Macros)
+
 ## Author
 
 - [Geektree0101](https://github.com/Geektree0101), david@daangn.com


### PR DESCRIPTION
Add requirement of adding `FLEXLAYOUT_SWIFT_PACKAGE` flag.
This flag is needed for using FlexLayout with SPM.